### PR TITLE
Add Ghidra Bookmarks when Rhabdomancer finds insecure functions

### DIFF
--- a/Rhabdomancer.java
+++ b/Rhabdomancer.java
@@ -258,6 +258,9 @@ public class Rhabdomancer extends GhidraScript
 							codeUnit.setComment(CodeUnit.PRE_COMMENT, tag + "\n" + cur);
 						}
 					}
+					if (getBookmarks(callAddr).length == 0) {
+						createBookmark(callAddr, "Insecure function - " + tag, dstName + " is called");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR add bookmarks capabilities to Rhabdomancer.
In this way it is possible to better handle calls to insecure functions on large binaries / code-bases.

PS: Ghidra only allows 1 bookmark for each address location so, if a bookmark is already present at a given location, Rhabdomancer skips it.

![image](https://github.com/0xdea/ghidra-scripts/assets/686894/b9771396-46fd-441f-8da8-9a087f5b7eca)
